### PR TITLE
fix: 비밀번호 최소 길이 8자로 프론트 validation 수정

### DIFF
--- a/src/screens/auth/LocalPassword.tsx
+++ b/src/screens/auth/LocalPassword.tsx
@@ -20,7 +20,7 @@ import { saveAccessToken, saveRefreshToken, saveUser } from '../../utils/authSto
 
 type Props = NativeStackScreenProps<RootStackParamList, 'LocalPassword'>;
 
-const isValidPassword = (v: string) => v.trim().length >= 6;
+const isValidPassword = (v: string) => v.trim().length >= 8;
 
 export default function LocalPassword({ navigation, route }: Props) {
   const [password, setPassword] = useState('');
@@ -119,7 +119,7 @@ export default function LocalPassword({ navigation, route }: Props) {
                 <TextInput
                   value={password}
                   onChangeText={onChangePassword}
-                  placeholder="6자리 이상 비밀번호를 입력해 주세요"
+                  placeholder="8자리 이상 비밀번호를 입력해 주세요"
                   placeholderTextColor="rgba(60, 60, 67, 0.3)"
                   secureTextEntry={!showPassword}
                   autoCapitalize="none"

--- a/src/screens/auth/ResetPasswordNewPw.tsx
+++ b/src/screens/auth/ResetPasswordNewPw.tsx
@@ -15,7 +15,7 @@ import type { RootStackParamList } from '../../navigation/RootNavigator';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'ResetPasswordNewPw'>;
 
-const isValidPassword = (v: string) => v.trim().length >= 6;
+const isValidPassword = (v: string) => v.trim().length >= 8;
 
 export default function ResetPasswordNewPw({ navigation, route }: Props) {
   const email = route.params?.email ?? '';
@@ -119,7 +119,7 @@ export default function ResetPasswordNewPw({ navigation, route }: Props) {
                 <TextInput
                   value={pw1}
                   onChangeText={setPw1}
-                  placeholder="6자리 이상 비밀번호를 입력해 주세요"
+                  placeholder="8자리 이상 비밀번호를 입력해 주세요"
                   placeholderTextColor="rgba(60, 60, 67, 0.3)"
                   secureTextEntry={!showPassword}
                   autoCapitalize="none"
@@ -146,7 +146,7 @@ export default function ResetPasswordNewPw({ navigation, route }: Props) {
 
               {/* ✅ input1 아래 메시지 */}
               {showPw1Error && (
-                <Text style={styles.errorText}>6자리 이상 입력해주세요</Text>
+                <Text style={styles.errorText}>8자리 이상 입력해주세요</Text>
               )}
               {showPw1Success && (
                 <Text style={styles.successText}>올바른 비밀번호입니다</Text>

--- a/src/screens/auth/SignUpPassword.tsx
+++ b/src/screens/auth/SignUpPassword.tsx
@@ -15,7 +15,7 @@ import type { RootStackParamList } from '../../navigation/RootNavigator';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'SignUpPassword'>;
 
-const isValidPassword = (v: string) => v.trim().length >= 6;
+const isValidPassword = (v: string) => v.trim().length >= 8;
 
 export default function SignUpPassword({ navigation, route }: Props) {
   const email = route.params?.email ?? '';
@@ -119,7 +119,7 @@ export default function SignUpPassword({ navigation, route }: Props) {
                 <TextInput
                   value={pw1}
                   onChangeText={setPw1}
-                  placeholder="6자리 이상 비밀번호를 입력해 주세요"
+                  placeholder="8자리 이상 비밀번호를 입력해 주세요"
                   placeholderTextColor="rgba(60, 60, 67, 0.3)"
                   secureTextEntry={!showPassword}
                   autoCapitalize="none"
@@ -146,7 +146,7 @@ export default function SignUpPassword({ navigation, route }: Props) {
 
               {/* ✅ input1 아래 메시지 */}
               {showPw1Error && (
-                <Text style={styles.errorText}>6자리 이상 입력해주세요</Text>
+                <Text style={styles.errorText}>8자리 이상 입력해주세요</Text>
               )}
               {showPw1Success && (
                 <Text style={styles.successText}>올바른 비밀번호입니다</Text>


### PR DESCRIPTION
## Summary
백엔드(8자 이상)와 프론트엔드(6자 이상) 간 비밀번호 정책 불일치로 인해 회원가입 시 400 에러가 발생하던 문제를 해결했습니다.  
프론트엔드 유효성 검사를 백엔드 기준(8자 이상)에 맞춰 수정했습니다.

---

## Changes
- 비밀번호 최소 길이 검증 기준 변경
  - 6자 이상 → **8자 이상**
- 회원가입 폼 validation 로직 수정
- 에러 메시지 및 placeholder 문구 통일
  - "비밀번호 (8자 이상)"
  - "비밀번호는 8자 이상 입력해주세요"

---

## Before
- 프론트: 6자 이상 허용
- 백엔드: 8자 이상 요구
- 결과: 회원가입 시 400 BAD_REQUEST 발생

---

## After
- 프론트/백엔드 모두 **8자 이상 기준으로 통일**
- 회원가입 정상 동작

---

## Related Issue
Closes #31 