### PR TITLE
feat: axios 토큰 자동 재발급(Refresh) 로직 구현 #33

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,24 +1,86 @@
+// src/api/axios.ts
 import axios from 'axios';
-import { getAccessToken } from '../utils/authStorage';
+import {
+  getAccessToken,
+  getRefreshToken,
+  saveAccessToken,
+  saveRefreshToken,
+  clearAllTokens,
+} from '../utils/authStorage';
 
 const BASE_URL = 'http://3.34.99.179:8080/api/v1';
 
-// ✅ 토큰 없이 쓰는 공개 API (회원가입/로그인/비번재설정 등)
+// ✅ 토큰 없이 쓰는 공개 API (회원가입/로그인/비번재설정/토큰재발급 등)
 export const publicApi = axios.create({
   baseURL: BASE_URL,
-  timeout: 200000,
+  timeout: 20000,
 });
 
 // ✅ 토큰 필요한 API (로그인 이후)
 const instance = axios.create({
   baseURL: BASE_URL,
-  timeout: 200000,
+  timeout: 20000,
 });
 
+// 1. 요청 인터셉터: API 쏠 때마다 Access Token 넣기
 instance.interceptors.request.use(async (config) => {
   const token = await getAccessToken();
   if (token) config.headers.Authorization = `Bearer ${token}`;
   return config;
 });
+
+// 2. 응답 인터셉터: 401 에러 발생 시 토큰 자동 재발급 (Refresh Token 활용)
+instance.interceptors.response.use(
+  (response) => {
+    // 정상 응답은 그대로 통과
+    return response;
+  },
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 만약 에러가 401(인증 만료)이고, 재시도한 적이 없는 요청이라면
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true; // 무한 루프 방지용 플래그
+
+      try {
+        const refreshToken = await getRefreshToken();
+
+        if (!refreshToken) {
+          throw new Error('Refresh Token이 없습니다.');
+        }
+
+        // 🚨 명세서대로 재발급 API 호출
+        const res = await publicApi.post('/auth/token/refresh', {
+          refreshToken: refreshToken,
+        });
+
+        // 명세서의 Success Response 구조에 맞게 새 토큰 추출
+        const newAccessToken = res.data.accessToken;
+        const newRefreshToken = res.data.refreshToken;
+
+        // 스토리지에 새 토큰들 저장
+        await saveAccessToken(newAccessToken);
+        await saveRefreshToken(newRefreshToken);
+
+        // 실패했던 원래 요청의 헤더에 새 Access Token을 끼워넣고 다시 쏘기
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return instance(originalRequest);
+
+      } catch (refreshError) {
+        // Refresh Token마저 만료되었거나 올바르지 않은 경우 (401, 400 에러 등)
+        console.log('토큰 재발급 실패(로그아웃 처리됨):', refreshError);
+
+        // 토큰들을 다 지워버림 -> 사용자는 다음 동작 시 자연스럽게 로그인 풀림 처리
+        await clearAllTokens();
+
+        // 에러를 그대로 반환하여 UI 컴포넌트(ProfileSetting 등)의 catch 블록으로 넘김
+        return Promise.reject(refreshError);
+      }
+    }
+
+    // 401 에러가 아니거나 이미 재시도한 경우라면 에러 그대로 반환
+    return Promise.reject(error);
+  }
+);
 
 export default instance;


### PR DESCRIPTION
# feat: axios 토큰 자동 재발급(Refresh) 로직 추가

## Description
AccessToken 만료 시 401 에러가 발생하던 문제를 해결하기 위해  
RefreshToken을 이용한 토큰 재발급 및 요청 재시도 로직을 추가합니다.

## Changes
- axios response interceptor 추가
- 401 발생 시 `/auth/token/refresh` 호출
- 새 access/refresh 토큰 저장
- 실패했던 요청 자동 재시도
- refresh 실패 시 토큰 삭제 및 로그아웃 처리

## Expected Result
- 토큰 만료 시 자동 재발급
- 사용자에게 401 에러 노출되지 않음
- 인증 API 정상 동작

## Related Issue
Closes #33