### PR TITLE
 feat: account-status 기반 이메일 인증 분기 로직 구현 #44

### DIFF
--- a/src/screens/auth/LocalLogin.tsx
+++ b/src/screens/auth/LocalLogin.tsx
@@ -13,6 +13,11 @@ import {
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../../navigation/RootNavigator';
 
+import { publicApi } from '../../api/axios';
+import { startKakaoLogin } from '../../utils/kakaoAuth';
+import ConfirmModal from '../../components/common/ConfirmModal';
+import Toast from '../../components/common/Toast';
+
 type Props = NativeStackScreenProps<RootStackParamList, 'LocalLogin'>;
 
 const isValidEmail = (v: string) =>
@@ -28,6 +33,27 @@ export default function LocalLogin({ navigation, route }: Props) {
 
   // ✅ mode: 'login'이면 LocalPassword, 그 외는 SignUpPassword
   const mode = route.params?.mode ?? 'signup';
+
+  // 모달 상태 관리 (카카오 로그인 및 복구/전환 선택용)
+  const [modalVisible, setModalVisible] = useState(false);
+  const [modalConfig, setModalConfig] = useState({
+    title: '',
+    message: '',
+    confirmText: '확인',
+    cancelText: '취소',
+    onConfirm: () => {},
+    onCancel: () => {},
+  });
+
+  // 토스트 상태 관리 (단순 알림용)
+  const [toastVisible, setToastVisible] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+
+  const showToast = (msg: string) => {
+    setToastMessage(msg);
+    setToastVisible(true);
+    setTimeout(() => setToastVisible(false), 1500);
+  };
 
   useEffect(() => {
     const showSub = Keyboard.addListener('keyboardDidShow', (e) => {
@@ -49,15 +75,72 @@ export default function LocalLogin({ navigation, route }: Props) {
   const showError = touched && trimmed.length > 0 && !canContinue;
   const showClear = trimmed.length > 0;
 
-  const onContinue = () => {
+  const onContinue = async () => {
     if (!canContinue) return;
 
-    if (mode === 'login') {
-      // ✅ 회원가입 완료 후 로그인 진입 → 비밀번호 입력 화면
-      navigation.navigate('LocalPassword', { email: trimmed });
-    } else {
-      // ✅ 최초 회원가입 플로우 → 비밀번호 설정 화면
-      navigation.navigate('SignUpPassword', { email: trimmed });
+    try {
+      // 1. 이메일 상태 조회
+      const res = await publicApi.get('/auth/account-status', {
+        params: { email: trimmed },
+      });
+      const { accountStatus } = res.data;
+
+      // 2. accountStatus 기준에 따른 동작 분기
+      switch (accountStatus) {
+        case 'ACTIVE_LOCAL':
+          // 활성 LOCAL 계정 → LOCAL 로그인 (비밀번호 입력 창)
+          navigation.navigate('LocalPassword', { email: trimmed });
+          break;
+
+        case 'ACTIVE_KAKAO':
+          // 활성 KAKAO 계정 → KAKAO 로그인 유도 (사용자 확인 필요)
+          setModalConfig({
+            title: '카카오 로그인',
+            message: '해당 이메일은 카카오로 가입된 계정입니다.\n카카오 로그인을 진행해주세요.',
+            confirmText: '카카오로 로그인',
+            cancelText: '취소',
+            onConfirm: () => {
+              setModalVisible(false);
+              startKakaoLogin();
+            },
+            onCancel: () => setModalVisible(false),
+          });
+          setModalVisible(true);
+          break;
+
+        case 'NEW_USER':
+        case 'DELETED_LOCAL':
+          // 신규 유저 또는 탈퇴한 LOCAL 계정 → LOCAL 회원가입/복구 진행
+          navigation.navigate('SignUpPassword', { email: trimmed });
+          break;
+
+        case 'DELETED_KAKAO':
+          // 탈퇴한 KAKAO 계정 → 복구(카카오) 또는 전환(로컬) 선택 (사용자 확인 필요)
+          setModalConfig({
+            title: '탈퇴한 카카오 계정 안내',
+            message: '카카오 로그인을 통해 계정을 복구하시거나\n이메일 로그인으로 전환하실 수 있습니다.',
+            confirmText: '카카오로 복구',
+            cancelText: '이메일로 전환',
+            onConfirm: () => {
+              setModalVisible(false);
+              startKakaoLogin();
+            },
+            onCancel: () => {
+              setModalVisible(false);
+              navigation.navigate('SignUpPassword', { email: trimmed });
+            },
+          });
+          setModalVisible(true);
+          break;
+
+        default:
+          // 그 외 알 수 없는 상태는 Toast로 가볍게 처리
+          showToast('계정 상태를 확인할 수 없습니다.');
+      }
+    } catch (error) {
+      console.log('이메일 상태 조회 실패:', error);
+      // 통신 실패와 같은 에러는 Toast로 가볍게 처리
+      showToast('계정 상태를 조회하는 데 실패했습니다.\n잠시 후 다시 시도해주세요.');
     }
   };
 
@@ -150,6 +233,18 @@ export default function LocalLogin({ navigation, route }: Props) {
           </View>
         </TouchableWithoutFeedback>
       </View>
+
+      <ConfirmModal
+        visible={modalVisible}
+        title={modalConfig.title}
+        message={modalConfig.message}
+        confirmText={modalConfig.confirmText}
+        cancelText={modalConfig.cancelText}
+        onConfirm={modalConfig.onConfirm}
+        onCancel={modalConfig.onCancel}
+      />
+
+      <Toast visible={toastVisible} message={toastMessage} />
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
# feat: account-status 기반 이메일 인증 분기 로직 구현

## Summary
이메일 입력 후 `/auth/account-status` API를 호출하여  
계정 상태(`accountStatus`)에 따라 로그인 / 회원가입 / 계정 복구 / 전환 플로우를 분기하도록 구현했습니다.

Soft Delete 정책에 맞춰 탈퇴 계정 복구 및 로그인 방식 전환 시나리오를 프론트 인증 플로우에 반영했습니다.

---

## Changes
- `/auth/account-status` API 연동
- 이메일 입력 후 계정 상태 조회 로직 추가
- `accountStatus` 값 기반 인증 분기 처리

### accountStatus 분기 처리
| accountStatus | 동작 |
|---|---|
| ACTIVE_LOCAL | LOCAL 로그인 (비밀번호 입력 화면) |
| ACTIVE_KAKAO | 카카오 로그인 안내 모달 표시 |
| NEW_USER | LOCAL 회원가입 진행 |
| DELETED_LOCAL | LOCAL 회원가입 → 계정 복구 |
| DELETED_KAKAO | 카카오 복구 또는 이메일 전환 선택 모달 |

### UI 추가
- `ConfirmModal` 추가 (카카오 로그인 유도 및 복구/전환 선택)
- `Toast` 추가 (에러 및 상태 안내)

### 기타
- 이메일 상태 조회 실패 시 Toast 처리
- 카카오 로그인 유도 시 `startKakaoLogin()` 호출

---

## Result
- Soft Delete 정책에 맞는 인증 플로우 구현
- 탈퇴 계정 재진입 시 계정 복구 지원
- LOCAL ↔ KAKAO 로그인 방식 전환 지원
- 사용자에게 명확한 로그인 안내 제공

---

## Test
- [x] ACTIVE_LOCAL → LocalPassword 화면 이동 확인
- [x] ACTIVE_KAKAO → 카카오 로그인 모달 표시 확인
- [x] NEW_USER → SignUpPassword 화면 이동 확인
- [x] DELETED_LOCAL → 회원가입 통해 계정 복구 확인
- [x] DELETED_KAKAO → 복구/전환 선택 모달 정상 동작

---

## Related Issue
Closes #44